### PR TITLE
Add __version__ attribute

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = xpartition
+version = attr: xpartition.__version__
 author = Spencer K. Clark
 author_email = spencerkclark@gmail.com
 license = MIT License

--- a/xpartition.py
+++ b/xpartition.py
@@ -11,6 +11,9 @@ import logging
 from typing import Callable, Dict, Hashable, List, Sequence, Tuple, Mapping
 
 
+__version__ = "0.1.0"
+
+
 DIMENSION_DIM = "dimension"
 SLICE_BOUND_DIM = "slice_bound"
 SLICE_BOUND_INDEX = pd.Index(["start", "stop"], name=SLICE_BOUND_DIM)


### PR DESCRIPTION
This adds a simple `__version__` attribute to the `xpartition` module.  In the future we can decide if we want to do something fancier, but for the initial version I think this is fine.