### PR TITLE
Simplify `blocks.indexers` and improve performance

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -2,167 +2,60 @@ import multiprocessing
 import os
 import string
 
-import pytest
+import dask
 import numpy as np
+import pytest
 import xarray as xr
 
 import xpartition
 
 
 @pytest.mark.parametrize(
-    ("value", "expected"),
-    [(1, True), (np.int32(1), True), (2.0, False), (np.float32(2), False)],
-)
-def test__is_integer(value, expected):
-    result = xpartition._is_integer(value)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("indexers", "exception"),
+    ("block_indexers", "expected", "exception"),
     [
-        ({"x": 0}, None),
-        ({"x": 4}, None),
-        ({"x": -4}, None),
-        ({"x": slice(1, 2)}, None),
-        ({"x": slice(1, 2, 1)}, None),
-        ({"x": 5}, IndexError),
-        ({"x": -5}, IndexError),
-        ({"x": 2.0}, ValueError),
-        ({"y": 0}, KeyError),
-        ({"x": slice(1, 2, 5)}, NotImplementedError),
+        ({"x": slice(0, 3)}, {"x": slice(0, 6)}, None),
+        ({"x": slice(1, 2)}, {"x": slice(2, 5)}, None),
+        ({"x": slice(-3, -2)}, {"x": slice(0, 2)}, None),
+        ({"x": slice(-3, -1)}, {"x": slice(0, 5)}, None),
+        ({"x": slice(-3, None)}, {"x": slice(0, 6)}, None),
+        ({"x": slice(None, 1)}, {"x": slice(0, 2)}, None),
+        ({"x": slice(0, 10)}, {"x": slice(0, 6)}, None),
+        ({"x": slice(-10, None)}, {"x": slice(0, 6)}, None),
+        ({"x": slice(None, None)}, {"x": slice(0, 6)}, None),
+        ({"x": slice(10, 12)}, {"x": slice(6, 6)}, None),
+        ({"x": slice(2, 1)}, {"x": slice(5, 2)}, None),
+        ({"x": 1}, {"x": slice(2, 5)}, None),
+        ({"x": -1}, {"x": slice(5, 6)}, None),
+        ({"x": -2}, {"x": slice(2, 5)}, None),
+        ({"x": np.int32(2)}, {"x": slice(2, 5)}, None),
+        ({"x": slice(0, 3), "y": 1}, {"x": slice(0, 6), "y": slice(3, 4)}, None),
+        ({"x": 4}, None, IndexError),
+        ({"x": -4}, None, IndexError),
+        ({"z": 1}, None, KeyError),
+        ({"x": slice(None, None, 2)}, None, NotImplementedError),
+        ({"x": 2.0}, None, ValueError),
     ],
     ids=lambda x: f"{x}",
 )
-def test__validate_indexers(indexers, exception):
-    sizes = {"x": 5}
-    if exception is not None:
-        with pytest.raises(exception):
-            xpartition._validate_indexers(indexers, sizes)
+def test_indexers(block_indexers, expected, exception):
+    data = dask.array.zeros((6, 4), chunks=((2, 3, 1), (3, 1)))
+    da = xr.DataArray(data, dims=["x", "y"])
+    if exception is None:
+        result = da.blocks.indexers(**block_indexers)
+        assert result == expected
     else:
-        xpartition._validate_indexers(indexers, sizes)
+        with pytest.raises(exception):
+            da.blocks.indexers(**block_indexers)
 
 
-@pytest.mark.parametrize(
-    ("indexers", "expected"),
-    [
-        ({"x": 5}, {"x": slice(5, 6)}),
-        ({"x": -5}, {"x": slice(-5, -4)}),
-        ({"x": slice(0, 2), "y": 5}, {"x": slice(0, 2), "y": slice(5, 6)}),
-    ],
-    ids=lambda x: f"{x}",
-)
-def test__convert_scalars_to_slices(indexers, expected):
-    result = xpartition._convert_scalars_to_slices(indexers)
-    assert result == expected
+def test_isel():
+    data = dask.array.random.random((6, 4), chunks=((2, 3, 1), (3, 1)))
+    da = xr.DataArray(data, dims=["x", "y"])
 
+    result = da.blocks.isel(x=slice(1, 2), y=1).data.compute()
+    expected = data.blocks[1:2, 1].compute()
 
-@pytest.mark.parametrize(
-    ("block_indexers", "expected"),
-    [
-        ({"x": slice(0, 3)}, {"x": slice(0, 6)}),
-        ({"x": slice(1, 2)}, {"x": slice(2, 5)}),
-        ({"x": slice(-3, -2)}, {"x": slice(0, 2)}),
-        ({"x": slice(-3, -1)}, {"x": slice(0, 5)}),
-        ({"x": slice(-3, None)}, {"x": slice(0, 6)}),
-        ({"x": slice(None, 1)}, {"x": slice(0, 2)}),
-        ({"x": slice(0, 10)}, {"x": slice(0, 6)}),
-        ({"x": slice(-10, None)}, {"x": slice(0, 6)}),
-        ({"x": slice(None, None)}, {"x": slice(0, 6)}),
-        ({"x": slice(10, 12)}, {"x": slice(6, 6)}),
-        ({"x": slice(2, 1)}, {"x": slice(5, 2)}),
-    ],
-    ids=lambda x: f"{x}",
-)
-def test__convert_block_indexers_to_array_indexers(block_indexers, expected):
-    chunks = {"x": (2, 3, 1)}
-    result = xpartition._convert_block_indexers_to_array_indexers(
-        block_indexers, chunks
-    )
-    assert result == expected
-
-
-def _construct_dataarray(shape, chunks, name):
-    dims = list(string.ascii_lowercase[: len(shape)])
-    data = np.random.random(shape)
-    da = xr.DataArray(data, dims=dims, name=name)
-    if chunks is not None:
-        chunks = {dim: chunk for dim, chunk in zip(dims, chunks)}
-        da = da.chunk(chunks)
-    return da
-
-
-SHAPE_AND_CHUNK_PAIRS = [
-    ((5,), (1,)),
-    ((5,), (2,)),
-    ((5,), (5,)),
-    ((2, 5), (1, 1)),
-    ((2, 5), (2, 1)),
-    ((2, 5), (2, 2)),
-    ((2, 5), (2, 4)),
-    ((2, 5), (2, 5)),
-    ((2, 1, 6), (1, 1, 1)),
-    ((2, 1, 6), (1, 1, 2)),
-    ((2, 1, 6), (2, 1, 2)),
-    ((2, 1, 6), (2, 1, 5)),
-    ((2, 3, 4, 5), (1, 1, 1, 1)),
-    ((2, 3, 4, 5), (2, 1, 3, 3)),
-]
-
-
-@pytest.fixture(params=SHAPE_AND_CHUNK_PAIRS, ids=lambda x: str(x))
-def da(request):
-    shape, chunks = request.param
-    name = "foo"
-    return _construct_dataarray(shape, chunks, name)
-
-
-def test_indexers_with_scalars(da):
-    n_blocks = np.product(da.blocks.shape)
-    for i in range(n_blocks):
-        block_indices = np.unravel_index(i, da.blocks.shape)
-        block_indexers = {dim: index for dim, index in zip(da.dims, block_indices)}
-        array_indexers = da.blocks.indexers(**block_indexers)
-        block_data_via_xarray = da.isel(array_indexers).data.compute()
-        block_data_via_dask = da.data.blocks[block_indices].compute()
-        np.testing.assert_array_equal(block_data_via_xarray, block_data_via_dask)
-
-        # Test obtaining the array through blocks.isel
-        block_data_via_xarray = da.blocks.isel(**block_indexers).data.compute()
-        np.testing.assert_array_equal(block_data_via_xarray, block_data_via_dask)
-
-
-@pytest.mark.parametrize(
-    "subset",
-    [
-        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 1)},
-        {"a": slice(0, 2), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 1)},
-        {"a": slice(0, 1), "b": slice(0, 2), "c": slice(0, 1), "d": slice(0, 1)},
-        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 2), "d": slice(0, 1)},
-        {"a": slice(0, 1), "b": slice(0, 1), "c": slice(0, 1), "d": slice(0, 2)},
-        {"a": slice(1, 2), "b": slice(1, 2), "c": slice(1, 2), "d": slice(1, 2)},
-        {"a": slice(0, 3), "b": slice(0, 1), "c": slice(1, 2), "d": slice(1, 2)},
-        {"a": slice(0, 3), "b": slice(0, 2), "c": slice(0, 1), "d": slice(0, 2)},
-        {"a": slice(0, 4), "b": slice(0, 2), "c": slice(0, 2), "d": slice(0, 2)},
-    ],
-    ids=lambda x: str(x),
-)
-def test_indexers_with_slices(subset):
-    shape = (4, 3, 2, 7)
-    chunks = (1, 2, 1, 5)
-    dims = list(string.ascii_lowercase[: len(shape)])
-    chunks = {dim: chunk for dim, chunk in zip(dims, chunks)}
-    data = np.random.random(shape)
-    da = xr.DataArray(data, dims=dims, name="foo").chunk(chunks)
-
-    indexers = da.blocks.indexers(**subset)
-    xarray_subset = da.isel(indexers).data.compute()
-    dask_subset = da.data.blocks[tuple(s for s in subset.values())].compute()
-    np.testing.assert_array_equal(xarray_subset, dask_subset)
-
-    # Test obtaining the array through blocks.isel
-    xarray_subset = da.blocks.isel(**subset).data.compute()
-    np.testing.assert_array_equal(xarray_subset, dask_subset)
+    np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.filterwarnings("ignore:Specified Dask chunks")

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -54,6 +54,30 @@ def test__convert_scalars_to_slices(indexers, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    ("block_indexers", "expected"),
+    [
+        ({"x": slice(0, 3)}, {"x": slice(0, 6)}),
+        ({"x": slice(1, 2)}, {"x": slice(2, 5)}),
+        ({"x": slice(-3, -2)}, {"x": slice(0, 2)}),
+        ({"x": slice(-3, -1)}, {"x": slice(0, 5)}),
+        ({"x": slice(-3, None)}, {"x": slice(0, 6)}),
+        ({"x": slice(None, 1)}, {"x": slice(0, 2)}),
+        ({"x": slice(0, 10)}, {"x": slice(0, 6)}),
+        ({"x": slice(-10, None)}, {"x": slice(0, 6)}),
+        ({"x": slice(None, None)}, {"x": slice(0, 6)}),
+        ({"x": slice(10, 12)}, {"x": slice(6, 6)}),
+    ],
+    ids=lambda x: f"{x}",
+)
+def test__convert_block_indexers_to_array_indexers(block_indexers, expected):
+    chunks = {"x": (2, 3, 1)}
+    result = xpartition._convert_block_indexers_to_array_indexers(
+        block_indexers, chunks
+    )
+    assert result == expected
+
+
 def _construct_dataarray(shape, chunks, name):
     dims = list(string.ascii_lowercase[: len(shape)])
     data = np.random.random(shape)

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -27,7 +27,7 @@ import xpartition
         ({"x": 1}, {"x": slice(2, 5)}, None),
         ({"x": -1}, {"x": slice(5, 6)}, None),
         ({"x": -2}, {"x": slice(2, 5)}, None),
-        ({"x": np.int32(2)}, {"x": slice(2, 5)}, None),
+        ({"x": np.int32(2)}, {"x": slice(5, 6)}, None),
         ({"x": slice(0, 3), "y": 1}, {"x": slice(0, 6), "y": slice(3, 4)}, None),
         ({"x": 4}, None, IndexError),
         ({"x": -4}, None, IndexError),
@@ -70,6 +70,16 @@ def test_dataarray_mappable_write(tmpdir, da, ranks):
 
     result = xr.open_zarr(store)
     xr.testing.assert_identical(result, ds)
+
+
+def _construct_dataarray(shape, chunks, name):
+    dims = list(string.ascii_lowercase[: len(shape)])
+    data = np.random.random(shape)
+    da = xr.DataArray(data, dims=dims, name=name)
+    if chunks is not None:
+        chunks = {dim: chunk for dim, chunk in zip(dims, chunks)}
+        da = da.chunk(chunks)
+    return da
 
 
 ALIGNED_SHAPE_AND_CHUNK_PAIRS = [

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -123,6 +123,10 @@ def test_indexers_with_scalars(da):
         block_data_via_dask = da.data.blocks[block_indices].compute()
         np.testing.assert_array_equal(block_data_via_xarray, block_data_via_dask)
 
+        # Test obtaining the array through blocks.isel
+        block_data_via_xarray = da.blocks.isel(**block_indexers).data.compute()
+        np.testing.assert_array_equal(block_data_via_xarray, block_data_via_dask)
+
 
 @pytest.mark.parametrize(
     "subset",
@@ -150,7 +154,10 @@ def test_indexers_with_slices(subset):
     indexers = da.blocks.indexers(**subset)
     xarray_subset = da.isel(indexers).data.compute()
     dask_subset = da.data.blocks[tuple(s for s in subset.values())].compute()
+    np.testing.assert_array_equal(xarray_subset, dask_subset)
 
+    # Test obtaining the array through blocks.isel
+    xarray_subset = da.blocks.isel(**subset).data.compute()
     np.testing.assert_array_equal(xarray_subset, dask_subset)
 
 

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -72,6 +72,31 @@ def test_dataarray_mappable_write(tmpdir, da, ranks):
     xr.testing.assert_identical(result, ds)
 
 
+SHAPE_AND_CHUNK_PAIRS = [
+    ((5,), (1,)),
+    ((5,), (2,)),
+    ((5,), (5,)),
+    ((2, 5), (1, 1)),
+    ((2, 5), (2, 1)),
+    ((2, 5), (2, 2)),
+    ((2, 5), (2, 4)),
+    ((2, 5), (2, 5)),
+    ((2, 1, 6), (1, 1, 1)),
+    ((2, 1, 6), (1, 1, 2)),
+    ((2, 1, 6), (2, 1, 2)),
+    ((2, 1, 6), (2, 1, 5)),
+    ((2, 3, 4, 5), (1, 1, 1, 1)),
+    ((2, 3, 4, 5), (2, 1, 3, 3)),
+]
+
+
+@pytest.fixture(params=SHAPE_AND_CHUNK_PAIRS, ids=lambda x: str(x))
+def da(request):
+    shape, chunks = request.param
+    name = "foo"
+    return _construct_dataarray(shape, chunks, name)
+
+
 def _construct_dataarray(shape, chunks, name):
     dims = list(string.ascii_lowercase[: len(shape)])
     data = np.random.random(shape)

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -6,7 +6,7 @@ import pytest
 import numpy as np
 import xarray as xr
 
-import xpartition
+import xpartition  # noqa: F401
 
 
 def _construct_dataarray(shape, chunks, name):

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -24,10 +24,13 @@ def test__is_integer(value, expected):
         ({"x": 0}, None),
         ({"x": 4}, None),
         ({"x": -4}, None),
+        ({"x": slice(1, 2)}, None),
+        ({"x": slice(1, 2, 1)}, None),
         ({"x": 5}, IndexError),
         ({"x": -5}, IndexError),
         ({"x": 2.0}, ValueError),
         ({"y": 0}, KeyError),
+        ({"x": slice(1, 2, 5)}, NotImplementedError),
     ],
     ids=lambda x: f"{x}",
 )
@@ -67,6 +70,7 @@ def test__convert_scalars_to_slices(indexers, expected):
         ({"x": slice(-10, None)}, {"x": slice(0, 6)}),
         ({"x": slice(None, None)}, {"x": slice(0, 6)}),
         ({"x": slice(10, 12)}, {"x": slice(6, 6)}),
+        ({"x": slice(2, 1)}, {"x": slice(5, 2)}),
     ],
     ids=lambda x: f"{x}",
 )
@@ -114,7 +118,7 @@ def da(request):
 
 
 def test_indexers_with_scalars(da):
-    n_blocks = np.product([size for size in da.blocks.sizes.values()])
+    n_blocks = np.product(da.blocks.shape)
     for i in range(n_blocks):
         block_indices = np.unravel_index(i, da.blocks.shape)
         block_indexers = {dim: index for dim, index in zip(da.dims, block_indices)}

--- a/xpartition.py
+++ b/xpartition.py
@@ -23,7 +23,7 @@ def _is_integer(value):
 
 
 def _convert_scalars_to_slices(kwargs):
-    """Convert a set of xarray dimension-index pairs to solely use slices.
+    """Convert a dict of xarray dimension-index pairs to solely use slices.
 
     Assumes that the index values have been validated already in
     _validate_indexers.
@@ -83,7 +83,7 @@ def _validate_indexers(kwargs, sizes):
 
 
 def _convert_block_indexers_to_array_indexers(kwargs, chunks):
-    """Convert a set of dask block indexers to array indexers.
+    """Convert a dict of dask block indexers to array indexers.
 
     Parameters
     ----------

--- a/xpartition.py
+++ b/xpartition.py
@@ -23,7 +23,20 @@ def _is_integer(value):
 
 
 def _convert_scalars_to_slices(kwargs):
-    """Convert a set of xarray dimension-index pairs to solely use slices."""
+    """Convert a set of xarray dimension-index pairs to solely use slices.
+
+    Assumes that the index values have be validated already in
+    _validate_indexers.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Dictionary mapping dimension names to integers or slices.
+
+    Returns
+    -------
+    dict
+    """
     result = {}
     for k, v in kwargs.items():
         if isinstance(v, slice):
@@ -34,7 +47,22 @@ def _convert_scalars_to_slices(kwargs):
 
 
 def _validate_indexers(kwargs, sizes):
-    """Check that indexers for an array with given sizes are valid."""
+    """Check that indexers for an array with given sizes are valid.
+
+    xpartition does not support indexing the blocks with non-contiguous array
+    regions, e.g. with slices that skip elements.  It also does not support
+    indexing with anything other than an integer or slice along a dimension.
+
+    Parameters
+    ----------
+    kwargs : dict Dictionary mapping dimension names to possible indexers. sizes
+        : dict Dictionary mapping dimension names to sizes of the array.
+
+    Raises
+    ------
+    KeyError, IndexError, NotImplementedError, or ValueError depending on the
+    context.
+    """
     for k, v in kwargs.items():
         if k not in sizes:
             raise KeyError(f"Dimension {k!r} is not a valid dimension.")
@@ -53,7 +81,21 @@ def _validate_indexers(kwargs, sizes):
 
 
 def _convert_block_indexers_to_array_indexers(kwargs, chunks):
-    """Convert a set of dask block indexers to array indexers."""
+    """Convert a set of dask block indexers to array indexers.
+
+    Parameters
+    ----------
+    kwargs : dict 
+        Dictionary mapping dimension names to slices.  The slices
+        represent slices in dask block space.
+    chunks : dict
+        Dictionary mapping dimension names to tuples representing 
+        the chunk structure of the given dimension.
+
+    Returns
+    -------
+    dict
+    """
     slices = {}
     for dim, indexer in kwargs.items():
         if indexer.start is None:

--- a/xpartition.py
+++ b/xpartition.py
@@ -84,7 +84,7 @@ class BlocksAccessor:
     def indexers(self, **kwargs) -> Region:
         _validate_indexers(kwargs, self.sizes)
         block_indexers = _convert_scalars_to_slices(kwargs)
-        return _convert_block_indexers_to_array_indexers(block_indexers, self.chunks)
+        return _convert_block_indexers_to_array_indexers(block_indexers, self._chunks)
 
     def isel(self, **kwargs) -> xr.DataArray:
         slices = self.indexers(**kwargs)

--- a/xpartition.py
+++ b/xpartition.py
@@ -25,7 +25,7 @@ def _is_integer(value):
 def _convert_scalars_to_slices(kwargs):
     """Convert a set of xarray dimension-index pairs to solely use slices.
 
-    Assumes that the index values have be validated already in
+    Assumes that the index values have been validated already in
     _validate_indexers.
 
     Parameters

--- a/xpartition.py
+++ b/xpartition.py
@@ -131,6 +131,40 @@ class BlocksAccessor:
         return {dim: size for dim, size in zip(self._obj.dims, self.shape)}
 
     def indexers(self, **kwargs) -> Region:
+        """Return a dict of array indexers that correspond to the provided block indexers.
+        
+        Parameters
+        ----------
+        **kwargs
+            Dimension-indexer pairs in dask block space.  These can be integers
+            or contiguous slices.
+
+        Returns
+        -------
+        dict
+
+        Examples
+        --------
+        >>> import xarray as xr; import dask.array as darray; import xpartition
+        >>> arr = darray.zeros((10, 20), chunks=(2, 5))
+        >>> da = xr.DataArray(arr, dims=["x", "y"], name="foo")
+        >>> da
+        <xarray.DataArray 'foo' (x: 10, y: 20)>
+        dask.array<zeros, shape=(10, 20), dtype=float64, chunksize=(2, 5), chunktype=numpy.ndarray>
+        Dimensions without coordinates: x, y
+        >>> da.blocks.indexers(x=2, y=3)
+        {'x': slice(4, 6, None), 'y': slice(15, 20, None)}
+        >>> da.blocks.indexers(x=2)
+        {'x': slice(4, 6, None)}
+        >>> da.blocks.indexers(x=slice(None, None))
+        {'x': slice(0, 10, None)}
+        >>> da.blocks.indexers(x=slice(None, 3))
+        {'x': slice(0, 6, None)}
+        >>> da.blocks.indexers(x=slice(3, None))
+        {'x': slice(6, 10, None)}
+        >>> da.blocks.indexers(x=2, y=slice(0, 2))
+        {'x': slice(4, 6, None), 'y': slice(0, 10, None)}
+        """
         _validate_indexers(kwargs, self.sizes)
         block_indexers = _convert_scalars_to_slices(kwargs)
         return _convert_block_indexers_to_array_indexers(block_indexers, self._chunks)

--- a/xpartition.py
+++ b/xpartition.py
@@ -42,7 +42,10 @@ def _convert_scalars_to_slices(indexers):
         if isinstance(v, slice):
             result[k] = v
         else:
-            result[k] = slice(v, v + 1)
+            if v == -1:
+                result[k] = slice(v, None)
+            else:
+                result[k] = slice(v, v + 1)
     return result
 
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -85,11 +85,11 @@ def _convert_block_indexers_to_array_indexers(kwargs, chunks):
 
     Parameters
     ----------
-    kwargs : dict 
+    kwargs : dict
         Dictionary mapping dimension names to slices.  The slices
         represent slices in dask block space.
     chunks : dict
-        Dictionary mapping dimension names to tuples representing 
+        Dictionary mapping dimension names to tuples representing
         the chunk structure of the given dimension.
 
     Returns

--- a/xpartition.py
+++ b/xpartition.py
@@ -55,8 +55,10 @@ def _validate_indexers(kwargs, sizes):
 
     Parameters
     ----------
-    kwargs : dict Dictionary mapping dimension names to possible indexers. sizes
-        : dict Dictionary mapping dimension names to sizes of the array.
+    kwargs : dict
+        Dictionary mapping dimension names to possible indexers.
+    sizes : dict
+        Dictionary mapping dimension names to sizes of the array.
 
     Raises
     ------

--- a/xpartition.py
+++ b/xpartition.py
@@ -131,8 +131,8 @@ class BlocksAccessor:
         return {dim: size for dim, size in zip(self._obj.dims, self.shape)}
 
     def indexers(self, **kwargs) -> Region:
-        """Return a dict of array indexers that correspond to the provided block indexers.
-        
+        """Return a dict of array indexers that correspond to the block indexers.
+
         Parameters
         ----------
         **kwargs

--- a/xpartition.py
+++ b/xpartition.py
@@ -43,9 +43,13 @@ def _validate_indexers(kwargs, sizes):
                 raise IndexError(
                     f"Index {v} is out of bounds for dimension {k!r} of length {sizes[k]}."
                 )
+        elif isinstance(v, slice):
+            if v.step is not None and v.step != 1:
+                raise NotImplementedError(
+                    "xpartition does not support indexing with slices with a step size different than None or 1."
+                )
         else:
-            if not isinstance(v, slice):
-                raise ValueError(f"Invalid indexer provided for dim {k!r}: {v}.")
+            raise ValueError(f"Invalid indexer provided for dim {k!r}: {v}.")
 
 
 def _convert_block_indexers_to_array_indexers(kwargs, chunks):

--- a/xpartition.py
+++ b/xpartition.py
@@ -28,10 +28,8 @@ def _convert_scalars_to_slices(kwargs):
     for k, v in kwargs.items():
         if isinstance(v, slice):
             result[k] = v
-        elif _is_integer(v):
-            result[k] = slice(v, v + 1)
         else:
-            raise ValueError(f"Invalid indexer provided for dim {k}: {v}.")
+            result[k] = slice(v, v + 1)
     return result
 
 
@@ -54,7 +52,10 @@ def _convert_block_indexers_to_array_indexers(kwargs, chunks):
     """Convert a set of dask block indexers to array indexers."""
     slices = {}
     for dim, indexer in kwargs.items():
-        start = sum(chunks[dim][: indexer.start])
+        if indexer.start is None:
+            start = 0
+        else:
+            start = sum(chunks[dim][: indexer.start])
         stop = sum(chunks[dim][: indexer.stop])
         slices[dim] = slice(start, stop)
     return slices


### PR DESCRIPTION
This PR greatly simplifies the implementation of `indexers`.  Previously we would compute the array indices of *every single dask block* whenever we would call `indexers`.  This is obviously substantially more work than is needed.  In reality we know which dask blocks we want to compute the indices of in advance, so we can compute those indices alone.  

For arrays without too many dask blocks this was not a big deal, but for arrays with many dask blocks, this was a performance bottleneck.

Resolves #3

## Simple benchmark

This PR results in a greater than 2000x speedup for the following benchmark.  With more chunks I would expect an even greater speedup.

Before:

```
In [1]: import dask.array as darray; import xarray as xr; import xpartition

In [2]: da = xr.DataArray(darray.random.random((10000, 10000), chunks=(100, 100)), dims=["x", "y"])

In [3]: %%timeit
   ...: da.blocks.indexers(x=slice(10, 20), y=slice(25, 50))
   ...: 
   ...: 
21.8 ms ± 195 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After:

```
In [1]: import dask.array as darray; import xarray as xr; import xpartition

In [2]: da = xr.DataArray(darray.random.random((10000, 10000), chunks=(100, 100)), dims=["x", "y"])

In [3]: %%timeit
   ...: da.blocks.indexers(x=slice(10, 20), y=slice(25, 50))
   ...: 
   ...: 
8.67 µs ± 341 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```