### PR TITLE
Only modify chunks over plan dimensions in `PartitionMapper._initialize_store`

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -205,8 +205,12 @@ def test_partition_partition():
     ids=lambda x: f"{x}",
 )
 @pytest.mark.parametrize("dtype", [float, int])
-def test__zeros_like_dataarray(original_chunks, override_chunks, expected_chunks, dtype):
-    da = xr.DataArray(np.zeros((10, 6), dtype=dtype), dims=["x", "y"]).chunk(original_chunks)
+def test__zeros_like_dataarray(
+    original_chunks, override_chunks, expected_chunks, dtype
+):
+    da = xr.DataArray(np.zeros((10, 6), dtype=dtype), dims=["x", "y"]).chunk(
+        original_chunks
+    )
     result = xpartition._zeros_like_dataarray(da, override_chunks)
     result_chunks = result.chunks
     assert result_chunks == expected_chunks
@@ -217,14 +221,24 @@ def test_zeros_like():
     shape = (2, 4)
     dims = ["x", "y"]
     attrs = {"foo": "bar"}
-    da1 = xr.DataArray(dask.array.random.random(shape), dims=dims, name="a", attrs=attrs)
-    da2 = xr.DataArray(dask.array.random.randint(0, size=shape), dims=dims, name="b", attrs=attrs)
-    da3 = xr.DataArray(dask.array.random.random(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs)
+    da1 = xr.DataArray(
+        dask.array.random.random(shape), dims=dims, name="a", attrs=attrs
+    )
+    da2 = xr.DataArray(
+        dask.array.random.randint(0, size=shape), dims=dims, name="b", attrs=attrs
+    )
+    da3 = xr.DataArray(
+        dask.array.random.random(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs
+    )
     ds = xr.merge([da1, da2, da3])
 
     zeros1 = xr.DataArray(dask.array.zeros(shape), dims=dims, name="a", attrs=attrs)
-    zeros2 = xr.DataArray(dask.array.zeros(shape, dtype=int), dims=dims, name="b", attrs=attrs)
-    zeros3 = xr.DataArray(dask.array.zeros(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs)
+    zeros2 = xr.DataArray(
+        dask.array.zeros(shape, dtype=int), dims=dims, name="b", attrs=attrs
+    )
+    zeros3 = xr.DataArray(
+        dask.array.zeros(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs
+    )
     expected = xr.merge([zeros1, zeros2, zeros3])
 
     result = xpartition.zeros_like(ds)

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -221,24 +221,23 @@ def test_zeros_like():
     shape = (2, 4)
     dims = ["x", "y"]
     attrs = {"foo": "bar"}
-    da1 = xr.DataArray(
-        dask.array.random.random(shape), dims=dims, name="a", attrs=attrs
-    )
-    da2 = xr.DataArray(
-        dask.array.random.randint(0, size=shape), dims=dims, name="b", attrs=attrs
-    )
-    da3 = xr.DataArray(
-        dask.array.random.random(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs
-    )
+
+    data1 = dask.array.random.random(shape)
+    data2 = dask.array.random.randint(0, size=shape)
+    data3 = dask.array.random.random(shape, chunks=(1, 1))
+
+    da1 = xr.DataArray(data1, dims=dims, name="a", attrs=attrs)
+    da2 = xr.DataArray(data2, dims=dims, name="b", attrs=attrs)
+    da3 = xr.DataArray(data3, dims=dims, name="c", attrs=attrs)
     ds = xr.merge([da1, da2, da3])
 
-    zeros1 = xr.DataArray(dask.array.zeros(shape), dims=dims, name="a", attrs=attrs)
-    zeros2 = xr.DataArray(
-        dask.array.zeros(shape, dtype=int), dims=dims, name="b", attrs=attrs
-    )
-    zeros3 = xr.DataArray(
-        dask.array.zeros(shape, chunks=(1, 1)), dims=dims, name="c", attrs=attrs
-    )
+    zeros1_data = dask.array.zeros(shape)
+    zeros2_data = dask.array.zeros(shape, dtype=int)
+    zeros3_data = dask.array.zeros(shape, chunks=(1, 1))
+
+    zeros1 = xr.DataArray(zeros1_data, dims=dims, name="a", attrs=attrs)
+    zeros2 = xr.DataArray(zeros2_data, dims=dims, name="b", attrs=attrs)
+    zeros3 = xr.DataArray(zeros3_data, dims=dims, name="c", attrs=attrs)
     expected = xr.merge([zeros1, zeros2, zeros3])
 
     result = xpartition.zeros_like(ds)

--- a/xpartition.py
+++ b/xpartition.py
@@ -339,7 +339,7 @@ def _zeros_like_dataarray(arr, override_chunks):
         override_chunks = {}
     chunks = _merge_chunks(arr, override_chunks)
     return xr.apply_ufunc(
-        dask.array.zeros_like, arr, kwargs=dict(chunks=chunks), dask="allowed"
+        dask.array.zeros, arr.shape, kwargs=dict(chunks=chunks), dask="allowed"
     )
 
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -325,13 +325,13 @@ class PartitionDatasetAccessor:
 
 
 def _merge_chunks(arr, override_chunks):
-    override_chunks = {
-        arr.get_axis_num(dim): sizes
-        for dim, sizes in override_chunks.items()
-        if dim in arr.dims
-    }
-    original_chunks = {dim: sizes for dim, sizes in enumerate(arr.chunks)}
-    return {**original_chunks, **override_chunks}
+    chunks_to_update = {}
+    for dim, sizes in override_chunks.items():
+        if dim in arr.dims:
+            axis = arr.get_axis_num(dim)
+            chunks_to_update[axis] = sizes
+    original_chunks = {axis: sizes for axis, sizes in enumerate(arr.chunks)}
+    return {**original_chunks, **chunks_to_update}
 
 
 def _zeros_like_dataarray(arr, override_chunks):
@@ -364,7 +364,7 @@ def zeros_like(ds: xr.Dataset, override_chunks=None):
     xr.Dataset
     """
     return ds.apply(
-        zeros_like_dataarray, override_chunks=override_chunks, keep_attrs=True
+        _zeros_like_dataarray, override_chunks=override_chunks, keep_attrs=True
     )
 
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -339,7 +339,7 @@ def _zeros_like_dataarray(arr, override_chunks):
         override_chunks = {}
     chunks = _merge_chunks(arr, override_chunks)
     return xr.apply_ufunc(
-        dask.array.zeros, arr.shape, kwargs=dict(chunks=chunks), dask="allowed"
+        dask.array.zeros_like, arr, kwargs=dict(chunks=chunks), dask="allowed"
     )
 
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -324,22 +324,48 @@ class PartitionDatasetAccessor:
         )
 
 
-def zeros_like_dataarray(arr, chunks):
-    dask_chunks = {
-        arr.get_axis_num(dim): size for dim, size in chunks.items() if dim in arr.dims
+def _merge_chunks(arr, override_chunks):
+    override_chunks = {
+        arr.get_axis_num(dim): sizes
+        for dim, sizes in override_chunks.items()
+        if dim in arr.dims
     }
+    original_chunks = {dim: sizes for dim, sizes in enumerate(arr.chunks)}
+    return {**original_chunks, **override_chunks}
+
+
+def _zeros_like_dataarray(arr, override_chunks):
+    if override_chunks is None:
+        override_chunks = {}
+    chunks = _merge_chunks(arr, override_chunks)
     return xr.apply_ufunc(
-        dask.array.zeros_like, arr, kwargs=dict(chunks=dask_chunks), dask="allowed"
+        dask.array.zeros_like, arr, kwargs=dict(chunks=chunks), dask="allowed"
     )
 
 
-def zeros_like(ds: xr.Dataset, chunks):
-    """Performant implementation of zeros_like with a given chunk size
+def zeros_like(ds: xr.Dataset, override_chunks=None):
+    """Performant implementation of zeros_like.
 
     xr.zeros_like(ds).chunk(chunks) is very slow for datasets with many
     changes.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset with dask-backed data variables.
+    override_chunks : dict
+        Dimension chunk-size pairs indicating any dimensions one would like to
+        override the original chunk sizes along.  For any dimensions that are not
+        present, zeros_like will use the chunk size along that dimension for each
+        variable in the input Dataset.
+
+    Returns
+    -------
+    xr.Dataset
     """
-    return ds.apply(zeros_like_dataarray, chunks=chunks, keep_attrs=True)
+    return ds.apply(
+        zeros_like_dataarray, override_chunks=override_chunks, keep_attrs=True
+    )
 
 
 class _ValidWorkPlan:
@@ -387,7 +413,9 @@ class PartitionMapper:
         for dim in dims_without_coords:
             iOut = iOut.assign_coords({dim: iOut[dim]})
 
-        schema = zeros_like(iOut.reindex(full_indexers), chunks=self.plan.output_chunks)
+        schema = zeros_like(
+            iOut.reindex(full_indexers), override_chunks=self.plan.output_chunks
+        )
         schema = schema.drop_vars(dims_without_coords)
         schema.partition.initialize_store(self.path)
 


### PR DESCRIPTION
This is the most straightforward way I can think of to address #8.  Here I have modified the behavior of our in-house `zeros_like` function to only *override* the chunk sizes over the specified dimensions.  The chunk size remains the original chunk size along any other dimensions in DataArrays in the provided Dataset.

I have updated the `test_PartitionMapper_integration` test to include cases that would fail prior to this change (e.g. cases where there the "y" dimension was also split across multiple chunks); these cases now pass.   I have also added tests for `_zeros_like_dataarray`, which is applied across data variables in `zeros_like`.

Resolves #8 