### PR TITLE
Fix invalid rank error

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -250,3 +250,10 @@ def test_zeros_like():
         # assert_identical does not check dtype or chunks
         assert result[var].dtype == expected[var].dtype
         assert result[var].chunks == expected[var].chunks
+
+
+def test_partition_indexers_invalid_rank_error():
+    data = dask.array.zeros((6, 4), chunks=((6, 4)))
+    da = xr.DataArray(data, dims=["x", "y"])
+    with pytest.raises(ValueError, match="greater than maximum rank"):
+        da.partition.indexers(1, 1, ["x"])

--- a/xpartition.py
+++ b/xpartition.py
@@ -295,8 +295,8 @@ class PartitionDataArrayAccessor:
         -------
         Dict[Hashable, slice]
         """
-        if (rank - 1) > ranks:
-            raise ValueError(f"Rank {rank} is greater than available ranks {ranks}.")
+        if rank >= ranks:
+            raise ValueError(f"Rank {rank} is greater than maximum rank {ranks - 1}.")
 
         meta_chunk_sizes = self._optimal_meta_chunk_sizes(ranks, dims)
         meta_array = self._meta_array(meta_chunk_sizes)


### PR DESCRIPTION
The previous implementation of the logic to catch whether a `rank` passed to `partition.indexers` was valid was incorrect.  The minus one is on the wrong side of the inequality; it should be either `rank > ranks - 1`, or, as I've implemented things now, `rank >= ranks`.  This PR adds a test and fixes this issue.  

In practice this was not a big deal, because it just meant that sometimes we would not trigger the error when we should have.