### PR TITLE
Add option to collect variable writes in `ds.partition.write`

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -278,7 +278,7 @@ def test_HashableIndexers(a, b):
 
 class CountingScheduler:
     """Inspired by xarray
-    
+
     https://github.com/pydata/xarray/blob/33fbb648ac042f821a11870ffa544e5bcb6e178f/xarray/tests/__init__.py#L97-L113
     """
 

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -290,18 +290,6 @@ class CountingScheduler:
         return dask.get(dsk, keys, **kwargs)
 
 
-@pytest.mark.parametrize(
-    "indexers", [{"a": slice(None, None, 3), "b": slice(1, 10, 2)}, None]
-)
-def test_HashableIndexers_from_immutable_representation(indexers):
-    hashable_indexers = xpartition.HashableIndexers(indexers)
-    immutable_representation = hashable_indexers.immutable_representation
-    result = xpartition.HashableIndexers.from_immutable_representation(
-        immutable_representation
-    )
-    assert result == hashable_indexers
-
-
 def test_dataset_mappable_write_minimizes_compute_calls(tmpdir):
     # This tests to ensure that calls to compute are minimized when writing
     # partitioned Datasets.  Previously, a compute was called separately for

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -268,7 +268,7 @@ def test_partition_indexers_invalid_rank_error():
         ),
         (None, None),
     ],
-    ids=lambda x: f"{x}"
+    ids=lambda x: f"{x}",
 )
 def test_freeze_unfreeze_indexers(unfrozen_indexers, frozen_indexers):
     assert xpartition.freeze_indexers(unfrozen_indexers) == frozen_indexers
@@ -284,7 +284,7 @@ def test_freeze_unfreeze_indexers(unfrozen_indexers, frozen_indexers):
         ),
         (None, None),
     ],
-    ids=lambda x: f"{x}"
+    ids=lambda x: f"{x}",
 )
 def test_hashability_of_frozen_indexers(a, b):
     assert a == b

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -317,7 +317,7 @@ class CountingScheduler:
 
 
 @pytest.mark.parametrize(
-    ("collect_variable_writes", "expected_computes"), [(True, 6), (False, 3)]
+    ("collect_variable_writes", "expected_computes"), [(False, 6), (True, 3)]
 )
 def test_dataset_mappable_write_minimizes_compute_calls(
     tmpdir, collect_variable_writes, expected_computes

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -326,7 +326,10 @@ def test_dataset_mappable_write_minimizes_compute_calls(
     # partitioned Datasets.  Previously, a compute was called separately for
     # each variable in the Dataset.  For fields that have common intermediates --
     # e.g. loading a particular variable from somewhere -- this is inefficient,
-    # because it means these intermediates must be computed multiple times.
+    # because it means these intermediates must be computed multiple times.  If
+    # the option to collect_variable_writes is turned, however, we expect more
+    # computes to be called (one for each partition and data variable in the
+    # Dataset).
     store = os.path.join(tmpdir, "test.zarr")
 
     foo = _construct_dataarray((2, 9), (2, 3), "foo")

--- a/xpartition.py
+++ b/xpartition.py
@@ -8,6 +8,7 @@ import xarray as xr
 import dataclasses
 import logging
 
+from dataclasses import dataclass
 from typing import Callable, Dict, Hashable, Sequence, Tuple, Mapping
 
 
@@ -188,9 +189,9 @@ def _write_partition_dataarray(
         ds.isel(partition).to_zarr(store, region=partition)
 
 
+@dataclass
 class HashableIndexers:
-    def __init__(self, indexers: Region):
-        self.indexers = indexers
+    indexers: Region
 
     @property
     def immutable_representation(self):

--- a/xpartition.py
+++ b/xpartition.py
@@ -391,7 +391,7 @@ class PartitionDatasetAccessor:
         collect_variable_writes: bool = False,
     ):
         """Write a Dataset partition to disk on a given rank.
-        
+
         Parameters
         ----------
         store : str
@@ -412,7 +412,7 @@ class PartitionDatasetAccessor:
             input data.  By default this input data would need be computed or
             loaded twice; with this option set to True, it the input data would
             only need to be computed or loaded once.  A caveat, however, is that
-            it can increase memory usage. 
+            it can increase memory usage.
         """
         if collect_variable_writes:
             f = _write_partition_dataset_via_collected_variables
@@ -428,7 +428,7 @@ class PartitionDatasetAccessor:
         collect_variable_writes: bool = False,
     ) -> Callable[[int], None]:
         """Return a function that can write data for a partition on a rank.
-        
+
         Parameters
         ----------
         store : str
@@ -447,8 +447,7 @@ class PartitionDatasetAccessor:
             input data.  By default this input data would need be computed or
             loaded twice; with this option set to True, it the input data would
             only need to be computed or loaded once.  A caveat, however, is that
-            it can increase memory usage. 
-        
+            it can increase memory usage.
         """
         if collect_variable_writes:
             f = _write_partition_dataset_via_collected_variables

--- a/xpartition.py
+++ b/xpartition.py
@@ -8,7 +8,6 @@ import xarray as xr
 import dataclasses
 import logging
 
-from dataclasses import dataclass
 from typing import Callable, Dict, Hashable, Sequence, Tuple, Mapping
 
 
@@ -189,9 +188,9 @@ def _write_partition_dataarray(
         ds.isel(partition).to_zarr(store, region=partition)
 
 
-@dataclass
 class HashableIndexers:
-    indexers: Dict[Hashable, slice]
+    def __init__(self, indexers: Region):
+        self.indexers = indexers
 
     @property
     def immutable_representation(self):

--- a/xpartition.py
+++ b/xpartition.py
@@ -203,13 +203,6 @@ class HashableIndexers:
     def __hash__(self):
         return hash(self.immutable_representation)
 
-    @classmethod
-    def from_immutable_representation(cls, immutable_representation):
-        if immutable_representation is None:
-            return cls(None)
-        else:
-            return cls({k: slice(*s) for k, s in immutable_representation})
-
 
 def _collect_by_partition(
     ds: xr.Dataset, ranks: int, dims: Sequence[Hashable], rank: int
@@ -219,31 +212,22 @@ def _collect_by_partition(
     """
     dataarrays = collections.defaultdict(list)
     for da in ds.data_vars.values():
-        partition_dims = [dim for dim in dims if dim in da.dims]
-        indexers = da.partition.indexers(ranks, rank, partition_dims)
-        if indexers is not None:
-            # We can ignore DataArrays whose indexers are None, because it
-            # means that no data needs to be written out from them on this
-            # rank.
-            key = HashableIndexers(indexers)
-            dataarrays[key].append(da)
-    return [(k.indexers, xr.merge(v)) for k, v in dataarrays.items()]
-
-
-def _filter_dask_backed_dataarrays(ds: xr.Dataset) -> xr.Dataset:
-    """Return a Dataset containing only dask-backed data variables."""
-    result = []
-    for da in ds.data_vars.values():
         if isinstance(da.data, dask.array.Array):
-            result.append(da)
-    return xr.merge(result)
+            partition_dims = [dim for dim in dims if dim in da.dims]
+            indexers = da.partition.indexers(ranks, rank, partition_dims)
+            if indexers is not None:
+                # We can ignore DataArrays whose indexers are None, because it
+                # means that no data needs to be written out from them on this
+                # rank.
+                key = HashableIndexers(indexers)
+                dataarrays[key].append(da)
+    return [(k.indexers, xr.merge(v)) for k, v in dataarrays.items()]
 
 
 def _write_partition_dataset(
     ds: xr.Dataset, store: str, ranks: int, dims: Sequence[Hashable], rank: int
 ):
-    dask_only_ds = _filter_dask_backed_dataarrays(ds)
-    collected_by_partition = _collect_by_partition(dask_only_ds, ranks, dims, rank)
+    collected_by_partition = _collect_by_partition(ds, ranks, dims, rank)
     for partition, d in collected_by_partition:
         d.isel(partition).to_zarr(store, region=partition)
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -448,6 +448,10 @@ class PartitionDatasetAccessor:
             loaded twice; with this option set to True, it the input data would
             only need to be computed or loaded once.  A caveat, however, is that
             it can increase memory usage.
+
+        Returns
+        -------
+        function
         """
         if collect_variable_writes:
             f = _write_partition_dataset_via_collected_variables

--- a/xpartition.py
+++ b/xpartition.py
@@ -220,7 +220,16 @@ def _collect_by_partition(
     return [(unfreeze_indexers(k), xr.merge(v)) for k, v in dataarrays.items()]
 
 
-def _write_partition_dataset(
+def _write_partition_dataset_via_individual_variables(
+    ds: xr.Dataset, store: str, ranks: int, dims: Sequence[Hashable], rank: int
+):
+    for da in ds.data_vars.values():
+        if isinstance(da.data, dask.array.Array):
+            partition_dims = [dim for dim in dims if dim in da.dims]
+            da.partition.write(store, ranks, partition_dims, rank)
+
+
+def _write_partition_dataset_via_collected_variables(
     ds: xr.Dataset, store: str, ranks: int, dims: Sequence[Hashable], rank: int
 ):
     collected_by_partition = _collect_by_partition(ds, ranks, dims, rank)
@@ -371,15 +380,32 @@ class PartitionDatasetAccessor:
     def initialize_store(self, store: str):
         self._obj.to_zarr(store, compute=False)
 
-    def write(self, store: str, ranks: int, dims: Sequence[Hashable], rank: int):
-        _write_partition_dataset(self._obj, store, ranks, dims, rank)
+    def write(
+        self,
+        store: str,
+        ranks: int,
+        dims: Sequence[Hashable],
+        rank: int,
+        collect_variable_writes: bool = False,
+    ):
+        if collect_variable_writes:
+            f = _write_partition_dataset_via_collected_variables
+        else:
+            f = _write_partition_dataset_via_individual_variables
+        f(self._obj, store, ranks, dims, rank)
 
     def mappable_write(
-        self, store: str, ranks: int, dims: Sequence[Hashable]
+        self,
+        store: str,
+        ranks: int,
+        dims: Sequence[Hashable],
+        collect_variable_writes: bool = False,
     ) -> Callable[[int], None]:
-        return functools.partial(
-            _write_partition_dataset, self._obj, store, ranks, dims
-        )
+        if collect_variable_writes:
+            f = _write_partition_dataset_via_collected_variables
+        else:
+            f = _write_partition_dataset_via_individual_variables
+        return functools.partial(f, self._obj, store, ranks, dims)
 
 
 def _merge_chunks(arr, override_chunks):


### PR DESCRIPTION
Currently the only way to write out partitioned Datasets is to iterate over each dask-backed DataArray it contained, writing its data out to disk one variable at at time.  This is convenient, because not every variable has the same chunk structure, and therefore may not have the same partition indexers for a given rank (a lot of times they do but it is possible they do not).  This is fine when all variables are independent of each other.  A drawback of this approach, however, is that if variables in the Dataset have common intermediates, those intermediates will need to be computed multiple times, even if the variables have the same chunk structure.  

This PR adds an option to reduce the number of required computes, by writing out DataArrays with common partition indexers in the same step.  This allows us to take advantage of the efficiency that comes with variables with common intermediates.  This option is called `collect_variable_writes`.  By default it is set to `False` for backwards compatibility.

A concrete example of when this is useful is in computing offline predictions using ML models -- for each variable a model predicts, we use the same inputs and still compute the rest of the outputs, regardless of whether we use those outputs or not.  If we are writing all outputs of an ML model to disk using xpartition, we shouldn't re-predict all fields when writing each variable (we should only need to call predict once).  