### PR TITLE
Prevent unsafe concurrent coordinate writes

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -199,7 +199,7 @@ def test_dataset_mappable_write(tmpdir, ds, ranks, collect_variable_writes):
 
     # Checkpoint modification times of all files associated with unchunked
     # variables after writing the chunked variables.  The modification times of
-    # the unchunked variables should be same as before writing the chunked
+    # the unchunked variables should be the same as before writing the chunked
     # variables.
     resulting_times = checkpoint_modification_times(store, unchunked_variables)
     assert expected_times == resulting_times


### PR DESCRIPTION
When concurrently writing partitions of DataArrays in a Dataset, any coordinates carried along by those DataArrays are also written concurrently.  These attached coordinates do not necessarily adhere to the same chunk structure as the DataArray itself.  This is an issue, since frequently they are completely unchunked, meaning that concurrent jobs attempt to write coordinates to the same blob files on disk, opening the possibility for data corruption.  In practice data corruption of coordinates has been rare, but we recently encountered a situation where it occurred.

This PR fixes this issue by dropping all coordinates when doing low-level partitioned writes.  As expected, now any unchunked coordinates or data variables are written once (and only once) during the store initialization step.  This PR also addresses the subtle issue of writing chunked coordinates by treating them as though they were independent data variables (previously we did not have test coverage for this case, though it is admittedly rare to encounter in practice).