### PR TITLE
Bump version: 0.2.0 → 0.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/xpartition.py
+++ b/xpartition.py
@@ -11,7 +11,7 @@ import logging
 from typing import Callable, Dict, Hashable, Mapping, Sequence, Tuple, Union
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 Region = Union[None, Mapping[Hashable, slice]]


### PR DESCRIPTION
This bumps the version of xpartition for a new release to include the fix in #17.