### PR TITLE
Address coordinate safety issue in PartitionMapper as well

### DIFF
--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -401,3 +401,16 @@ def test_dataset_mappable_write_minimizes_compute_calls(
 
     result = xr.open_zarr(store)
     xr.testing.assert_identical(result, ds)
+
+
+def test_get_unchunked_variable_names():
+    a = xr.DataArray(
+        np.zeros((3, 5)), dims=["x", "y"], coords=[range(3), range(5)], name="a"
+    )
+    b = a.copy(deep=True).rename("b").chunk({"x": 1})
+    c = xr.DataArray(np.zeros(3), dims=["x"]).chunk({"x": 1})
+    ds = xr.merge([a, b])
+    ds = ds.assign_coords(c=c)
+    expected = {"x", "y", "a"}
+    result = set(xpartition.get_unchunked_variable_names(ds))
+    assert result == expected

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -153,14 +153,6 @@ def get_files(directory):
     return files
 
 
-def get_unchunked_variable_names(ds):
-    names = []
-    for name, variable in ds.variables.items():
-        if not isinstance(variable.data, dask.array.Array):
-            names.append(name)
-    return names
-
-
 def checkpoint_modification_times(store, variables):
     times = {}
     for variable in variables:
@@ -175,7 +167,7 @@ def checkpoint_modification_times(store, variables):
 @pytest.mark.parametrize("ranks", [1, 2, 3, 5, 10, 11])
 @pytest.mark.parametrize("collect_variable_writes", [False, True])
 def test_dataset_mappable_write(tmpdir, ds, ranks, collect_variable_writes):
-    unchunked_variables = get_unchunked_variable_names(ds)
+    unchunked_variables = xpartition.get_unchunked_variable_names(ds)
 
     store = os.path.join(tmpdir, "test.zarr")
     ds.partition.initialize_store(store)
@@ -225,7 +217,7 @@ def test_PartitionMapper_integration(
         chunked_coord = xr.DataArray(range(5), dims=["x"]).chunk({"x": 5})
         ds = ds.assign_coords(b=chunked_coord)
 
-    unchunked_variables = get_unchunked_variable_names(ds)
+    unchunked_variables = xpartition.get_unchunked_variable_names(ds)
 
     store = str(tmpdir)
     mapper = ds.z.partition.map(store, ranks=3, dims=["x"], func=func, data=ds)

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -206,10 +206,13 @@ def test_dataset_mappable_write(tmpdir, ds, ranks, collect_variable_writes):
 
 
 @pytest.mark.parametrize("has_coord", [True, False])
+@pytest.mark.parametrize("has_chunked_coord", [True, False])
 @pytest.mark.parametrize(
     "original_chunks", [{"x": 2}, {"x": 2, "y": 5}], ids=lambda x: f"{x}"
 )
-def test_PartitionMapper_integration(tmpdir, has_coord, original_chunks):
+def test_PartitionMapper_integration(
+    tmpdir, has_coord, has_chunked_coord, original_chunks
+):
     def func(ds):
         return ds.rename(z="new_name").assign_attrs(dataset_attr="fun")
 
@@ -218,6 +221,9 @@ def test_PartitionMapper_integration(tmpdir, has_coord, original_chunks):
     )
     if has_coord:
         ds = ds.assign_coords(x=range(5))
+    if has_chunked_coord:
+        chunked_coord = xr.DataArray(range(5), dims=["x"]).chunk({"x": 5})
+        ds = ds.assign_coords(b=chunked_coord)
 
     unchunked_variables = get_unchunked_variable_names(ds)
 

--- a/test_xpartition.py
+++ b/test_xpartition.py
@@ -404,13 +404,14 @@ def test_dataset_mappable_write_minimizes_compute_calls(
 
 
 def test_get_unchunked_variable_names():
-    a = xr.DataArray(
-        np.zeros((3, 5)), dims=["x", "y"], coords=[range(3), range(5)], name="a"
-    )
+    dims = ["x", "y"]
+    coords = [range(3), range(5)]
+    a = xr.DataArray(np.zeros((3, 5)), dims=dims, coords=coords, name="a")
     b = a.copy(deep=True).rename("b").chunk({"x": 1})
-    c = xr.DataArray(np.zeros(3), dims=["x"]).chunk({"x": 1})
+    c = a.copy(deep=True).rename("c").chunk({"x": 1})
     ds = xr.merge([a, b])
     ds = ds.assign_coords(c=c)
+
     expected = {"x", "y", "a"}
     result = set(xpartition.get_unchunked_variable_names(ds))
     assert result == expected

--- a/xpartition.py
+++ b/xpartition.py
@@ -572,7 +572,7 @@ class PartitionMapper:
         region = self.plan.input_partition[rank]
         iData = self.data.isel(region)
         iOut = self.func(iData)
-        iOut.to_zarr(self.path, region=region)
+        iOut.drop(iOut.coords).to_zarr(self.path, region=region)
         logging.info(f"Done writing {rank + 1}.")
 
     def __iter__(self):

--- a/xpartition.py
+++ b/xpartition.py
@@ -544,6 +544,36 @@ def get_unchunked_variable_names(ds):
     return unchunked
 
 
+def get_unchunked_non_dimension_coord_names(ds):
+    names = []
+    for name, da in ds.coords.items():
+        if name not in ds.dims and isinstance(da.data, np.ndarray):
+            names.append(name)
+    return names
+
+
+def get_unchunked_data_var_names(ds):
+    names = []
+    for name, da in ds.data_vars.items():
+        if isinstance(da.data, np.ndarray):
+            names.append(name)
+    return names
+
+
+def validate_PartitionMapper_dataset(ds):
+    unchunked_non_dimension_coords = get_unchunked_non_dimension_coord_names(ds)
+    unchunked_data_vars = get_unchunked_data_var_names(ds)
+    invalid_unchunked_vars = unchunked_non_dimension_coords + unchunked_data_vars
+    if invalid_unchunked_vars:
+        raise ValueError(
+            f"The PartitionMapper approach does not support writing datasets that "
+            f"contain unchunked non-dimension coordinates or data variables.  "
+            f"Consider dropping or chunking these before initiating the write or "
+            f"switching to the traditional xpartition writing approach.  The "
+            f"variables in question are {invalid_unchunked_vars!r}."
+        )
+
+
 @dataclasses.dataclass
 class PartitionMapper:
     """Evaluate a function on each region of a partition and store the output
@@ -563,6 +593,8 @@ class PartitionMapper:
         region = self.plan.input_partition[0]
         iData = self.data.isel(region)
         iOut = self.func(iData)
+        validate_PartitionMapper_dataset(iOut)
+
         full_indexers = {dim: self.data[dim] for dim in self.dims}
 
         dims_without_coords = (set(iOut.dims) - set(iOut.indexes)) & set(self.dims)


### PR DESCRIPTION
This is a followup to #17, which addresses the same issue in the `PartitionMapper` as well.