### PR TITLE
Add more basic examples to the README.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8.git
-    rev: 4.0.1
+    rev: 6.1.0
     hooks:
       - id: flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,17 @@ setup_requires =
 	setuptools_scm
 
 [flake8]
-ignore = 
-	E203 # whitespace before ':' - doesn't work well with black
-	E402 # module level import not at top of file
-	E501 # line too long - let black worry about that
-	E731 # do not assign a lambda expression, use a def
-	W503 # line break before binary operator
+ignore =
+	# whitespace before ':' - doesn't work well with black
+	E203
+	# module level import not at top of file
+	E402
+	# line too long - let black worry about that
+	E501
+	# do not assign a lambda expression, use a def
+	E731
+	# line break before binary operator
+	W503
 exclude = 
 	.eggs
 	doc


### PR DESCRIPTION
The SLURM example is maybe a little off-putting to lead with in the README.  This PR adds some simpler cases which maybe make it easier to understand how xpartition works, and how one could adapt it for their own needs.