### PR TITLE
Update GitHub actions badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # xpartition
 
-[![Build
-Status](https://github.com/spencerkclark/xpartition/workflows/tests/badge.svg?branch=main)](https://github.com/spencerkclark/xpartition/actions)
+[![Build Status](https://github.com/spencerkclark/xpartition/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/spencerkclark/xpartition/actions)
 [![codecov](https://codecov.io/gh/spencerkclark/xpartition/branch/main/graph/badge.svg?token=H1DBBSTQ2V)](https://codecov.io/gh/spencerkclark/xpartition)
 [![PyPI](https://img.shields.io/pypi/v/xpartition.svg)](https://pypi.python.org/pypi/xpartition/)
 


### PR DESCRIPTION
The GitHub actions badge in the README was broken.  This fixes it.