### PR TITLE
Bump version: 0.2.2 → 2025.03.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 0.2.2
-commit = True
-tag = True
-
 [metadata]
 name = xpartition
 version = attr: xpartition.__version__
@@ -52,7 +47,3 @@ exclude =
 	.eggs
 	doc
 	__init__.py
-
-[bumpversion:file:xpartition.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/xpartition/xpartition.py
+++ b/xpartition/xpartition.py
@@ -11,7 +11,7 @@ import xarray as xr
 
 from xpartition.xarray_utils import get_chunks_encoding
 
-__version__ = "0.2.2"
+__version__ = "2025.03.0"
 
 
 Region = Union[None, Mapping[Hashable, slice]]


### PR DESCRIPTION
Here we shift to using calendar versioning and migrate away from `bumpversion`, which is no longer maintained.